### PR TITLE
Fix: Prioritize exact shop matches in !offers command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>Antony</groupId>
 	<artifactId>Antony</artifactId>
-	<version>7.16.0</version>
+	<version>7.16.1</version>
 
 	<properties>
 		<resteasy.version>6.2.11.Final</resteasy.version>

--- a/src/main/java/bot/antony/commands/ChangelogCmd.java
+++ b/src/main/java/bot/antony/commands/ChangelogCmd.java
@@ -44,6 +44,7 @@ public class ChangelogCmd extends ServerCommand {
 	private List<ChangeLogEntry> getChangeLog(int limit) {
 		String cmdPrefix = Antony.getCmdPrefix();
 		List<ChangeLogEntry> changeLog = new ArrayList<>();
+        changeLog.add(new ChangeLogEntry("19.08.2025 - Version 7.16.1", "Bugfix: Der ***" + cmdPrefix + "offers*** Befehl berücksichtigt nun exakte Shopnamen vor Teiltreffern, um mehrdeutige Ergebnisse zu vermeiden."));
         changeLog.add(new ChangeLogEntry("18.08.2025 - Version 7.16.0", "***" + cmdPrefix + "offers*** wurde hinzugefügt, um alle Angebote eines Shops anzeigen zu lassen."));
 		changeLog.add(new ChangeLogEntry("09.06.2025 - Version 7.15.1", "Bugfix: Der Befehl ***" + cmdPrefix + "sells*** läuft nun nicht mehr in ein Zeichenlimit, dass die Ausgabe verhindert."));
 		changeLog.add(new ChangeLogEntry("19.03.2025 - Version 7.15.0", "Der Befehl ***" + cmdPrefix + "notify*** wurde so angepasst, dass nun auch Threads berücksichtigt werden können."));

--- a/src/main/java/bot/antony/commands/OffersCmd.java
+++ b/src/main/java/bot/antony/commands/OffersCmd.java
@@ -53,10 +53,23 @@ public class OffersCmd extends ServerCommand {
             return;
         }
 
-        List<Shop> matchingShops = controller.getNonBLOnlineShops().stream()
-                .filter(shop -> shop.getName().equalsIgnoreCase(searchString)
-                        || shop.getName().toLowerCase().contains(searchString.toLowerCase()))
+        List<Shop> allShops = controller.getNonBLOnlineShops();
+        List<Shop> matchingShops;
+
+        // First: check for exact matches (case-insensitive, trimmed)
+        List<Shop> exactMatches = allShops.stream()
+                .filter(shop -> shop.getName().equalsIgnoreCase(searchString.trim()))
                 .collect(Collectors.toList());
+
+        if (!exactMatches.isEmpty()) {
+            // If there are exact matches, prefer them
+            matchingShops = exactMatches;
+        } else {
+            // If no exact matches are found, fall back to partial matches
+            matchingShops = allShops.stream()
+                    .filter(shop -> shop.getName().toLowerCase().contains(searchString.toLowerCase()))
+                    .collect(Collectors.toList());
+        }
 
         // No shop found with the given search string. Send error message.
         if (matchingShops.isEmpty()) {


### PR DESCRIPTION
This PR fixes inconsistent behavior in the !offers command when searching for shops.
Previously, the search could return multiple or no results due to ambiguous partial matches (e.g. Exotic Ants vs Exotic AntsWorld).

Changes:
- Added two-phase matching logic:
  - First check for exact matches (case-insensitive, trimmed).
  - If no exact match is found, fallback to partial matches.
- Ensures stable and predictable results for shop lookups.

Impact:
- Users will now always get the correct shop when providing the exact name.
- Prevents confusion with similarly named shops.